### PR TITLE
#157903304 Create endpoint for admin to disapprove a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="logoSmall.png" alt='logo'/>
 
-[![Build Status](https://travis-ci.com/omobosteven/maintenance-tracker.svg?branch=ft-approve-request-157903279)](https://travis-ci.com/omobosteven/maintenance-tracker)
-[![Coverage Status](https://coveralls.io/repos/github/omobosteven/maintenance-tracker/badge.svg?branch=ft-approve-request-157903279)](https://coveralls.io/github/omobosteven/maintenance-tracker?branch=ft-approve-request-157903279)
+[![Build Status](https://travis-ci.com/omobosteven/maintenance-tracker.svg?branch=ft-disapprove-request-157903304)](https://travis-ci.com/omobosteven/maintenance-tracker)
+[![Coverage Status](https://coveralls.io/repos/github/omobosteven/maintenance-tracker/badge.svg?branch=ft-disapprove-request-157903304)](https://coveralls.io/github/omobosteven/maintenance-tracker?branch=ft-disapprove-request-157903304)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a6fde1bb2915cec5032e/maintainability)](https://codeclimate.com/github/omobosteven/maintenance-tracker/maintainability)
 
 # Maintenance-tracker
@@ -69,6 +69,11 @@ Maintenance Tracker App is an application that provides users with the ability t
     <td>PUT</td>
     <td>/api/v1/requests/:id/approve</td>
     <td>Approve request</td>
+  </tr>
+  <tr>
+    <td>PUT</td>
+    <td>/api/v1/requests/:id/disapprove</td>
+    <td>Disapprove request</td>
   </tr>
   <tr>
     <td>POST</td>

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -49,4 +49,12 @@ requests.put(
   AdminRequestsController.updateRequestStatus,
 );
 
+requests.put(
+  '/requests/:id/disapprove',
+  Authorization.verifyUser,
+  Authorization.verifyAdmin,
+  Validation.validateId,
+  AdminRequestsController.updateRequestStatus,
+);
+
 export default requests;

--- a/server/tests/adminRequestController.spec.js
+++ b/server/tests/adminRequestController.spec.js
@@ -24,6 +24,26 @@ describe('Tests for admin requests API endpoints', () => {
       });
   });
 
+  it('should create request', (done) => {
+    chai.request(app)
+      .post('/api/v1/users/requests')
+      .set('x-access-token', userToken)
+      .set('Content-type', 'application/json')
+      .send({
+        type: 'maintenance',
+        category: 'computers',
+        item: 'laptop',
+        description: 'faulty screen',
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(201);
+        expect(res.body.message).to.equal('request created successfully');
+        expect(res.body.data.request.item).to.equal('laptop');
+        expect(res.body.data.request.description).to.equal('faulty screen');
+        done();
+      });
+  });
+
   it('should fetch all the requests in the system', (done) => {
     chai.request(app)
       .get('/api/v1/requests')
@@ -50,6 +70,30 @@ describe('Tests for admin requests API endpoints', () => {
         expect(res).to.have.status(200);
         expect(res.body.message).to.equal('Request approved');
         expect(res.body.data.request.status).to.equal('approved');
+        done();
+      });
+  });
+
+  it('should disapprove a request', (done) => {
+    chai.request(app)
+      .put('/api/v1/requests/2/disapprove')
+      .set('x-access-token', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body.message).to.equal('Request disapproved');
+        expect(res.body.data.request.status).to.equal('disapproved');
+        done();
+      });
+  });
+
+  it('should fail if admin tries to disapporve an approved request', (done) => {
+    chai.request(app)
+      .put('/api/v1/requests/1/disapprove')
+      .set('x-access-token', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body.status).to.equal('fail');
+        expect(res.body.message).to.equal('Request was not found');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
- Create an endpoint for admin to disapprove requests on the database

#### Description of Task to be completed?
- An Admin should be able to disapprove requests on the database

#### How should this be manually tested?
- Clone the project locally from `git clone https://github.com/omobosteven/maintenance-tracker.git`
- Navigate to the project in your terminal
- Install all the necessary dependencies as stated in the README file
- run `$ npm install`
- create database specify in the .env file
- Run app locally using `$ npm run start-dev`
- Run `$ npm run db-migrate`
- Create a request
- Open postman and make a `PUT request` to the URL `http://localhost:3000/api/v1/requests/:id/disapprove`

#### Any background context you want to provide?
- Request id must be an integer
- Admin must be logged in and authenticated

#### What are the relevant pivotal tracker stories?
- story type: feature
- story id: 157903304
- story title: Admin should be able to disapprove a request

#### ScreenShots:

#### What are the relevant Github Issues?
- none

#### Questions:
- none