### PR TITLE
#157903328 Create endpoint for admin to resolve a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="logoSmall.png" alt='logo'/>
 
-[![Build Status](https://travis-ci.com/omobosteven/maintenance-tracker.svg?branch=ft-disapprove-request-157903304)](https://travis-ci.com/omobosteven/maintenance-tracker)
-[![Coverage Status](https://coveralls.io/repos/github/omobosteven/maintenance-tracker/badge.svg?branch=ft-disapprove-request-157903304)](https://coveralls.io/github/omobosteven/maintenance-tracker?branch=ft-disapprove-request-157903304)
+[![Build Status](https://travis-ci.com/omobosteven/maintenance-tracker.svg?branch=ft-resolve-request-157903328)](https://travis-ci.com/omobosteven/maintenance-tracker)
+[![Coverage Status](https://coveralls.io/repos/github/omobosteven/maintenance-tracker/badge.svg?branch=ft-resolve-request-157903328)](https://coveralls.io/github/omobosteven/maintenance-tracker?branch=ft-resolve-request-157903328)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a6fde1bb2915cec5032e/maintainability)](https://codeclimate.com/github/omobosteven/maintenance-tracker/maintainability)
 
 # Maintenance-tracker
@@ -74,6 +74,11 @@ Maintenance Tracker App is an application that provides users with the ability t
     <td>PUT</td>
     <td>/api/v1/requests/:id/disapprove</td>
     <td>Disapprove request</td>
+  </tr>
+  <tr>
+    <td>PUT</td>
+    <td>/api/v1/requests/:id/resolve</td>
+    <td>Resolve request</td>
   </tr>
   <tr>
     <td>POST</td>

--- a/server/controllers/AdminRequestsController.js
+++ b/server/controllers/AdminRequestsController.js
@@ -11,7 +11,9 @@ class AdminRequestsController extends Controller {
    * @return {Object} Returned object
    */
   static getAllRequests(req, res) {
-    const queryFetchAllRequests = 'SELECT * FROM requests';
+    const queryFetchAllRequests =
+    `SELECT * FROM requests
+    ORDER BY requestid DESC`;
 
     db.connect()
       .then((client) => {

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -57,4 +57,12 @@ requests.put(
   AdminRequestsController.updateRequestStatus,
 );
 
+requests.put(
+  '/requests/:id/resolve',
+  Authorization.verifyUser,
+  Authorization.verifyAdmin,
+  Validation.validateId,
+  AdminRequestsController.updateRequestStatus,
+);
+
 export default requests;

--- a/server/tests/adminRequestController.spec.js
+++ b/server/tests/adminRequestController.spec.js
@@ -52,10 +52,10 @@ describe('Tests for admin requests API endpoints', () => {
         expect(res).to.have.status(200);
         expect(res.body.message).to.equal('All Requests');
         expect(res.body.data.requests).to.be.an('array');
-        expect(res.body.data.requests[0].requestid).to.equal(1);
+        expect(res.body.data.requests[0].requestid).to.equal(2);
         expect(res.body.data.requests[0].description).to
-          .equal('faulty keyboard');
-        expect(res.body.data.requests[0].type).to.equal('repair');
+          .equal('faulty screen');
+        expect(res.body.data.requests[0].type).to.equal('maintenance');
         expect(res.body.data.requests[0].category).to.equal('computers');
         expect(res.body.data.requests[0].item).to.equal('laptop');
         done();
@@ -94,6 +94,18 @@ describe('Tests for admin requests API endpoints', () => {
         expect(res).to.have.status(404);
         expect(res.body.status).to.equal('fail');
         expect(res.body.message).to.equal('Request was not found');
+        done();
+      });
+  });
+
+  it('should resolve a request', (done) => {
+    chai.request(app)
+      .put('/api/v1/requests/1/resolve')
+      .set('x-access-token', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body.message).to.equal('Request resolved');
+        expect(res.body.data.request.status).to.equal('resolved');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
- Create an endpoint for admin to resolve requests on the database

#### Description of Task to be completed?
- An Admin should be able to resolve requests on the database

#### How should this be manually tested?
- Clone the project locally from `git clone https://github.com/omobosteven/maintenance-tracker.git`
- Navigate to the project in your terminal
- Install all the necessary dependencies as stated in the README file
- run `$ npm install`
- create database specify in the .env file
- Run app locally using `$ npm run start-dev`
- Run `$ npm run db-migrate`
- Create a request
- Open postman and make a `PUT request` to the URL `http://localhost:3000/api/v1/requests/:id/resolve`

#### Any background context you want to provide?
- Request id must be an integer
- Admin must be logged in and authenticated

#### What are the relevant pivotal tracker stories?
- story type: feature
- story id: 157903328
- story title: Admin should be able to resolve a request

#### ScreenShots:
![request resolved](https://user-images.githubusercontent.com/33634109/40667938-39ced92a-635b-11e8-82a7-90958b878903.png)

#### What are the relevant Github Issues?
- none

#### Questions:
- none