### PR TITLE
 #157961138 Check requests status before user can modify the requests

### DIFF
--- a/server/controllers/RequestsController.js
+++ b/server/controllers/RequestsController.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this, consistent-return */
 import Controller from './Controller';
 import db from '../models/db';
 
@@ -170,6 +171,13 @@ class RequestsController extends Controller {
               });
             }
 
+            if (request.rows[0].status !== 'pending') {
+              return res.status(403).json({
+                status: 'fail',
+                message: 'Not allowed, requests has been processed',
+              });
+            }
+
             const requestUpdate = {
               ...request.rows[0],
               ...req.body,
@@ -191,7 +199,7 @@ class RequestsController extends Controller {
              WHERE requestid = '${id}'
              RETURNING *`;
 
-            return client.query(queryUpdateRequest)
+            client.query(queryUpdateRequest)
               .then((updatedRequest) => {
                 client.release();
                 return res.status(200).json({

--- a/server/tests/adminRequestController.spec.js
+++ b/server/tests/adminRequestController.spec.js
@@ -133,4 +133,22 @@ describe('Tests for admin requests API endpoints', () => {
         done();
       });
   });
+
+  it('should fail if user tries to update a processed requests', (done) => {
+    chai.request(app)
+      .put('/api/v1/users/requests/2')
+      .set('x-access-token', userToken)
+      .send({
+        type: 'maintenance',
+        category: 'computers',
+        item: 'laptop',
+        description: 'faulty screen',
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(403);
+        expect(res.body.message).to
+          .equal('Not allowed, requests has been processed');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- Refactor the modify requests endpoint for user

#### Description of Task to be completed?
- User should not be able to modify a request that has been approved, disapproved or resolved

#### How should this be manually tested?
- Clone the project locally from `git clone https://github.com/omobosteven/maintenance-tracker.git`
- Navigate to the project in your terminal
- Install all the necessary dependencies as stated in the README file
- run `$ npm install`
- create database specify in the .env file
- Run app locally using `$ npm run start-dev`
- Run `$ npm run db-migrate`
- Open postman and make a `GET request` to the URL `http://localhost:3000/api/v1/users/requests/:id`

#### Any background context you want to provide?
- User must be logged in and authenticated

#### What are the relevant pivotal tracker stories?
- story type: feature
- story id: 157961138
- story title: Authenticated user should not be able to modify a request that has been approved, disapproved or resolved

#### ScreenShots:

#### What are the relevant Github Issues?
- none

#### Questions:
- none