### PR TITLE
 #158004064 Add API documentation link to app URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <img src="logoSmall.png" alt='logo'/>
 
-[![Build Status](https://travis-ci.com/omobosteven/maintenance-tracker.svg?branch=ft-user-requests-157988591)](https://travis-ci.com/omobosteven/maintenance-tracker)
-[![Coverage Status](https://coveralls.io/repos/github/omobosteven/maintenance-tracker/badge.svg?branch=ft-user-requests-157988591)](https://coveralls.io/github/omobosteven/maintenance-tracker?branch=ft-user-requests-157988591)
+[![Build Status](https://travis-ci.com/omobosteven/maintenance-tracker.svg?branch=ch-api-docs-158004064)](https://travis-ci.com/omobosteven/maintenance-tracker)
+[![Coverage Status](https://coveralls.io/repos/github/omobosteven/maintenance-tracker/badge.svg?branch=ch-api-docs-158004064)](https://coveralls.io/github/omobosteven/maintenance-tracker?branch=ch-api-docs-158004064)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a6fde1bb2915cec5032e/maintainability)](https://codeclimate.com/github/omobosteven/maintenance-tracker/maintainability)
 
 # Maintenance-tracker
 Maintenance Tracker App is an application that provides users with the ability to reach out to operations or repairs department regarding repair or maintenance requests and monitor the status of their request.
 
-* [Maintenance-tracker on Heroku](https://maintenance-tracker-stv.herokuapp.com/)
+* [Maintenance-tracker API documentation](https://maintenance-tracker-stv.herokuapp.com/)
 
 ## Features
 * User can create an account and log in

--- a/server/app.js
+++ b/server/app.js
@@ -11,10 +11,8 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, '../client')));
 
-app.get('/', (req, res) => res.json({
-  status: 'success',
-  message: 'Welcome to maintenance tracker App',
-}));
+app.get('/', (req, res) =>
+  res.redirect('https://app.swaggerhub.com/apis/omobosteven/maintenance-tracker/1.0.0'));
 app.use(routes);
 
 const port = parseInt(process.env.PORT, 10) || 3000;


### PR DESCRIPTION
#### What does this PR do?
- Add API documentation link to app URL

#### Description of Task to be completed?
- Write API documentation and add it to the app's url

#### How should this be manually tested?
- Go to the URL `https://maintenance-tracker-stv.herokuapp.com/`

#### Any background context you want to provide?
- none

#### What are the relevant pivotal tracker stories?
- story type: chore
- story id: 158004064
- story title: Add API documentation link to app URL

#### ScreenShots:
- none

#### What are the relevant Github Issues?
- none

#### Questions:
- none